### PR TITLE
NOOK-5860 Add LinkedTxn to VendorCredit

### DIFF
--- a/quickbooks/objects/vendorcredit.py
+++ b/quickbooks/objects/vendorcredit.py
@@ -44,6 +44,7 @@ class VendorCredit(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEn
         self.FromAccountRef = None
         self.ToAccountRef = None
 
+        self.LinkedTxn = []
         self.Line = []
 
     def __str__(self):


### PR DESCRIPTION
LinkedTxn is returned from the Quickbooks API for minor versions >= 55:  https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/vendorcredit